### PR TITLE
Automatically create `seeds/` folder if missing

### DIFF
--- a/src/bin/self_play.rs
+++ b/src/bin/self_play.rs
@@ -166,7 +166,10 @@ async fn main() {
 			"notes": notes,
 			"options": { "variant": variant.name }
 		}).to_string();
-		fs::write(format!("seeds/{i}.json"), data).expect("Should be able to write to `/foo/tmp`");
+		if let Err(e) = fs::create_dir_all("seeds") {
+			log::error!("Could not create seeds/ directory: {e:?}");
+		}
+		fs::write(format!("seeds/{i}.json"), data).expect(&format!("Should be able to write to `seeds/{i}.json`"));
 
 		println!("Seed {}: Score: {}, Result: {:?}", i, score, result);
 	}


### PR DESCRIPTION
Without this change, `self_play` errors on a fresh clone when trying to create the file `seeds/0.json` since the `seeds/` folder is not present. (It is gitignored.)