### PR TITLE
Add support for joining password-unprotected tables

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -345,6 +345,8 @@ impl BotClient {
 							None =>
 								send_pm(&self.ws, who, "Room is password protected, please provide a password.")
 						}
+					} else {
+						send_cmd(&self.ws, "tableJoin", &json!({ "tableID": table.id }).to_string())
 					}
 				}
 				None => send_pm(&self.ws, who, "Could not join, as you are not in a room.")


### PR DESCRIPTION
Currently if you're in a password-unprotected table and you do `/pm BOTNAME /join`, the bot simply does nothing.